### PR TITLE
Anmol Kapoor - UCSB Organization Controller & Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -23,7 +23,7 @@ import javax.validation.Valid;
 
 
 @Api(description = "UCSBOrganization")
-@RequestMapping("/api/ucsborganization")
+@RequestMapping("/api/UCSBOrganization")
 @RestController
 @Slf4j
 public class UCSBOrganizationController extends ApiController {

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -43,9 +43,9 @@ public class UCSBOrganizationController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("")
     public UCSBOrganization getById(
-            @ApiParam("orgCode") @RequestParam String orgCode) {
-        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
-                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+            @ApiParam("id") @RequestParam String id) {
+        UCSBOrganization org = ucsbOrganizationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
 
         return org;
     }
@@ -54,7 +54,6 @@ public class UCSBOrganizationController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public UCSBOrganization postOrgs(
-        @ApiParam("orgCode") @RequestParam String orgCode,
         @ApiParam("orgTranslationShort") @RequestParam String orgTranslationShort,
         @ApiParam("orgTranslation") @RequestParam String orgTranslation,
         @ApiParam("inactive") @RequestParam boolean inactive
@@ -62,7 +61,6 @@ public class UCSBOrganizationController extends ApiController {
         {
 
         UCSBOrganization newOrg = new UCSBOrganization();
-        newOrg.setOrgCode(orgCode);
         newOrg.setOrgTranslationShort(orgTranslationShort);
         newOrg.setOrgTranslation(orgTranslation);
         newOrg.setInactive(inactive);
@@ -76,26 +74,24 @@ public class UCSBOrganizationController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("")
     public Object deleteOrg(
-            @ApiParam("orgCode") @RequestParam String orgCode) {
-        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
-                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+            @ApiParam("id") @RequestParam String id) {
+        UCSBOrganization org = ucsbOrganizationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
 
         ucsbOrganizationRepository.delete(org);
-        return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(id));
     }
 
     @ApiOperation(value = "Update a single organization")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("")
     public UCSBOrganization updateOrg(
-            @ApiParam("orgCode") @RequestParam String orgCode,
+            @ApiParam("id") @RequestParam String id,
             @RequestBody @Valid UCSBOrganization incoming) {
 
-        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
-                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+        UCSBOrganization org = ucsbOrganizationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
 
-
-        org.setOrgCode(incoming.getOrgCode());  
         org.setOrgTranslationShort(incoming.getOrgTranslationShort());
         org.setOrgTranslation(incoming.getOrgTranslation());
         org.setInactive(incoming.getInactive());

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,107 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+
+@Api(description = "UCSBOrganization")
+@RequestMapping("/api/ucsborganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+    @Autowired
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @ApiOperation(value = "List API for all the UCSB Organizations")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allOrgs() {
+        Iterable<UCSBOrganization> orgs = ucsbOrganizationRepository.findAll();
+        return orgs;
+    }
+
+    @ApiOperation(value = "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @ApiParam("orgCode") @RequestParam String orgCode) {
+        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        return org;
+    }
+
+    @ApiOperation(value = "Create a new organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postOrgs(
+        @ApiParam("orgCode") @RequestParam String orgCode,
+        @ApiParam("orgTranslationShort") @RequestParam String orgTranslationShort,
+        @ApiParam("orgTranslation") @RequestParam String orgTranslation,
+        @ApiParam("inactive") @RequestParam boolean inactive
+        )
+        {
+
+        UCSBOrganization newOrg = new UCSBOrganization();
+        newOrg.setOrgCode(orgCode);
+        newOrg.setOrgTranslationShort(orgTranslationShort);
+        newOrg.setOrgTranslation(orgTranslation);
+        newOrg.setInactive(inactive);
+
+        UCSBOrganization savedOrg = ucsbOrganizationRepository.save(newOrg);
+
+        return savedOrg;
+    }
+
+    @ApiOperation(value = "Delete a UCSB Organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteOrg(
+            @ApiParam("orgCode") @RequestParam String orgCode) {
+        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        ucsbOrganizationRepository.delete(org);
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
+    }
+
+    @ApiOperation(value = "Update a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateOrg(
+            @ApiParam("orgCode") @RequestParam String orgCode,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+
+        org.setOrgCode(incoming.getOrgCode());  
+        org.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        org.setOrgTranslation(incoming.getOrgTranslation());
+        org.setInactive(incoming.getInactive());
+
+        ucsbOrganizationRepository.save(org);
+
+        return org;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -54,6 +54,7 @@ public class UCSBOrganizationController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public UCSBOrganization postOrgs(
+        @ApiParam("orgCode") @RequestParam String orgCode,
         @ApiParam("orgTranslationShort") @RequestParam String orgTranslationShort,
         @ApiParam("orgTranslation") @RequestParam String orgTranslation,
         @ApiParam("inactive") @RequestParam boolean inactive
@@ -61,6 +62,7 @@ public class UCSBOrganizationController extends ApiController {
         {
 
         UCSBOrganization newOrg = new UCSBOrganization();
+        newOrg.setOrgCode(orgCode);
         newOrg.setOrgTranslationShort(orgTranslationShort);
         newOrg.setOrgTranslation(orgTranslation);
         newOrg.setInactive(inactive);

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -19,7 +19,6 @@ import lombok.Builder;
 @Entity(name = "ucsborganization")
 public class UCSBOrganization {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private String orgCode;
     private String orgTranslationShort;
     private String orgTranslation;

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -40,24 +40,24 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
         @MockBean
         UserRepository userRepository;
 
-        // Authorization tests for /api/ucsbdiningcommons/admin/all
+        // Authorization tests for /api/UCSBOrganization/admin/all
 
         @Test
         public void logged_out_users_cannot_get_all() throws Exception {
-                mockMvc.perform(get("/api/ucsborganization/all"))
+                mockMvc.perform(get("/api/UCSBOrganization/all"))
                                 .andExpect(status().is(403)); // logged out users can't get all
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_users_can_get_all() throws Exception {
-                mockMvc.perform(get("/api/ucsborganization/all"))
+                mockMvc.perform(get("/api/UCSBOrganization/all"))
                                 .andExpect(status().is(200)); // logged
         }
 
         @Test
         public void logged_out_users_cannot_get_by_id() throws Exception {
-                mockMvc.perform(get("/api/ucsborganization?orgCode=POINT"))
+                mockMvc.perform(get("/api/UCSBOrganization?orgCode=POINT"))
                                 .andExpect(status().is(403)); // logged out users can't get by id
         }
 
@@ -66,14 +66,14 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
         @Test
         public void logged_out_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/ucsborganization/post"))
+                mockMvc.perform(post("/api/UCSBOrganization/post"))
                                 .andExpect(status().is(403));
         }
 
         @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_regular_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/ucsborganization/post"))
+                mockMvc.perform(post("/api/UCSBOrganization/post"))
                                 .andExpect(status().is(403)); // only admins can post
         }
 
@@ -95,7 +95,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 when(ucsbOrganizationRepository.findById(eq("POINT"))).thenReturn(Optional.of(orgs));
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=POINT"))
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?orgCode=POINT"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -115,7 +115,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 when(ucsbOrganizationRepository.findById(eq("VRL"))).thenReturn(Optional.empty());
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=VRL"))
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?orgCode=VRL"))
                                 .andExpect(status().isNotFound()).andReturn();
 
                 // assert
@@ -152,7 +152,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrgs);
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/ucsborganization/all"))
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization/all"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -179,7 +179,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/ucsborganization/post?orgCode=DSC&orgTranslationShort=DS Club&orgTranslation=Data Science Club&inactive=true")
+                                post("/api/UCSBOrganization/post?orgCode=DSC&orgTranslationShort=DS Club&orgTranslation=Data Science Club&inactive=true")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -206,7 +206,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/ucsborganization?orgCode=BGC")
+                                delete("/api/UCSBOrganization?orgCode=BGC")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -228,7 +228,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/ucsborganization?orgCode=iphone-users")
+                                delete("/api/UCSBOrganization?orgCode=iphone-users")
                                                 .with(csrf()))
                                 .andExpect(status().isNotFound()).andReturn();
 
@@ -263,7 +263,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/ucsborganization?orgCode=fac")
+                                put("/api/UCSBOrganization?orgCode=fac")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)
@@ -295,7 +295,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/ucsborganization?orgCode=FM")
+                                put("/api/UCSBOrganization?orgCode=FM")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -86,6 +86,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization orgs = UCSBOrganization.builder()
+                                .orgCode("POINT")
                                 .orgTranslationShort("POINT (Physics)")
                                 .orgTranslation("Physics Organization for Innovation and Technology")
                                 .inactive(false)
@@ -132,6 +133,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization point = UCSBOrganization.builder()
+                                .orgCode("POINT T")
                                 .orgTranslationShort("POINT (Technology)")
                                 .orgTranslation("Physics Organization for Innovation and Technology")
                                 .inactive(true)
@@ -166,6 +168,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization dsclub = UCSBOrganization.builder()
+                                .orgCode("DSC")
                                 .orgTranslationShort("DS Club")
                                 .orgTranslation("Data Science Club")
                                 .inactive(true)
@@ -175,7 +178,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/UCSBOrganization/post?orgTranslationShort=DS Club&orgTranslation=Data Science Club&inactive=true")
+                                post("/api/UCSBOrganization/post?orgCode=DSC&orgTranslationShort=DS Club&orgTranslation=Data Science Club&inactive=true")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -192,6 +195,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization boardgame = UCSBOrganization.builder()
+                                .orgCode("BGC")
                                 .orgTranslationShort("BG Club")
                                 .orgTranslation("Board Game Club")
                                 .inactive(true)
@@ -239,12 +243,14 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization facultyOrig = UCSBOrganization.builder()
+                                .orgCode("fac")
                                 .orgTranslationShort("faculty")
                                 .orgTranslation("Faculty Workers Only")
                                 .inactive(false)
                                 .build();
 
                 UCSBOrganization facultyEdited = UCSBOrganization.builder()
+                                .orgCode("fac")
                                 .orgTranslationShort("faculty & students")
                                 .orgTranslation("Faculty and Student Workers")
                                 .inactive(true)
@@ -276,6 +282,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization editedOrgs = UCSBOrganization.builder()
+                                .orgCode("FM")
                                 .orgTranslationShort("F. Machines")
                                 .orgTranslation("Fast Machines")
                                 .inactive(true)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,311 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UCSBOrganizationRepository ucsbOrganizationRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/ucsbdiningcommons/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsborganization/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsborganization/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/ucsborganization?orgCode=POINT"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        // Authorization tests for /api/ucsborganization/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsborganization/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsborganization/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                UCSBOrganization orgs = UCSBOrganization.builder()
+                                .orgCode("POINT")
+                                .orgTranslationShort("POINT (Physics)")
+                                .orgTranslation("Physics Organization for Innovation and Technology")
+                                .inactive(false)
+                                .build();
+
+                when(ucsbOrganizationRepository.findById(eq("POINT"))).thenReturn(Optional.of(orgs));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=POINT"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("POINT"));
+                String expectedJson = mapper.writeValueAsString(orgs);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("VRL"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=VRL"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("VRL"));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id VRL not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbdiningcommons() throws Exception {
+
+                // arrange
+
+                UCSBOrganization point = UCSBOrganization.builder()
+                                .orgCode("POINT")
+                                .orgTranslationShort("POINT (Technology)")
+                                .orgTranslation("Physics Organization for Innovation and Technology")
+                                .inactive(true)
+                                .build();
+
+                UCSBOrganization vrl = UCSBOrganization.builder()
+                                .orgCode("VRL")
+                                .orgTranslationShort("Virl")
+                                .orgTranslation("Vision Research Laboratory")
+                                .inactive(false)
+                                .build();
+
+                ArrayList<UCSBOrganization> expectedOrgs = new ArrayList<>();
+                expectedOrgs.addAll(Arrays.asList(point, vrl));
+
+                when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrgs);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganization/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedOrgs);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_commons() throws Exception {
+                // arrange
+
+                UCSBOrganization dsclub = UCSBOrganization.builder()
+                                .orgCode("DSC")
+                                .orgTranslationShort("DS Club")
+                                .orgTranslation("Data Science Club")
+                                .inactive(true)
+                                .build();
+
+                when(ucsbOrganizationRepository.save(eq(dsclub))).thenReturn(dsclub);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/ucsborganization/post?orgCode=DSC&orgTranslationShort=DS Club&orgTranslation=Data Science Club&inactive=true")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).save(dsclub);
+                String expectedJson = mapper.writeValueAsString(dsclub);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_date() throws Exception {
+                // arrange
+
+                UCSBOrganization boardgame = UCSBOrganization.builder()
+                                .orgCode("BGC")
+                                .orgTranslationShort("BG Club")
+                                .orgTranslation("Board Game Club")
+                                .inactive(true)
+                                .build();
+
+                when(ucsbOrganizationRepository.findById(eq("BGC"))).thenReturn(Optional.of(boardgame));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsborganization?orgCode=BGC")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("BGC");
+                verify(ucsbOrganizationRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id BGC deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_commons_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("iphone-users"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsborganization?orgCode=iphone-users")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("iphone-users");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id iphone-users not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_commons() throws Exception {
+                // arrange
+
+                UCSBOrganization facultyOrig = UCSBOrganization.builder()
+                                .orgCode("fac")
+                                .orgTranslationShort("faculty")
+                                .orgTranslation("Faculty Workers Only")
+                                .inactive(false)
+                                .build();
+
+                UCSBOrganization facultyEdited = UCSBOrganization.builder()
+                                .orgCode("facnstu")
+                                .orgTranslationShort("faculty & students")
+                                .orgTranslation("Faculty and Student Workers")
+                                .inactive(true)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(facultyEdited);
+
+                when(ucsbOrganizationRepository.findById(eq("fac"))).thenReturn(Optional.of(facultyOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsborganization?orgCode=fac")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("fac");
+                verify(ucsbOrganizationRepository, times(1)).save(facultyEdited); // should be saved with updated info
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_commons_that_does_not_exist() throws Exception {
+                // arrange
+
+                UCSBOrganization editedOrgs = UCSBOrganization.builder()
+                                .orgCode("FM")
+                                .orgTranslationShort("F. Machines")
+                                .orgTranslation("Fast Machines")
+                                .inactive(true)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(editedOrgs);
+
+                when(ucsbOrganizationRepository.findById(eq("FM"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsborganization?orgCode=FM")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("FM");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id FM not found", json.get("message"));
+
+        }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -57,7 +57,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
         @Test
         public void logged_out_users_cannot_get_by_id() throws Exception {
-                mockMvc.perform(get("/api/UCSBOrganization?orgCode=POINT"))
+                mockMvc.perform(get("/api/UCSBOrganization?id=POINT"))
                                 .andExpect(status().is(403)); // logged out users can't get by id
         }
 
@@ -86,7 +86,6 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization orgs = UCSBOrganization.builder()
-                                .orgCode("POINT")
                                 .orgTranslationShort("POINT (Physics)")
                                 .orgTranslation("Physics Organization for Innovation and Technology")
                                 .inactive(false)
@@ -95,7 +94,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 when(ucsbOrganizationRepository.findById(eq("POINT"))).thenReturn(Optional.of(orgs));
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?orgCode=POINT"))
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?id=POINT"))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -115,7 +114,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 when(ucsbOrganizationRepository.findById(eq("VRL"))).thenReturn(Optional.empty());
 
                 // act
-                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?orgCode=VRL"))
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?id=VRL"))
                                 .andExpect(status().isNotFound()).andReturn();
 
                 // assert
@@ -133,14 +132,12 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization point = UCSBOrganization.builder()
-                                .orgCode("POINT")
                                 .orgTranslationShort("POINT (Technology)")
                                 .orgTranslation("Physics Organization for Innovation and Technology")
                                 .inactive(true)
                                 .build();
 
                 UCSBOrganization vrl = UCSBOrganization.builder()
-                                .orgCode("VRL")
                                 .orgTranslationShort("Virl")
                                 .orgTranslation("Vision Research Laboratory")
                                 .inactive(false)
@@ -169,7 +166,6 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization dsclub = UCSBOrganization.builder()
-                                .orgCode("DSC")
                                 .orgTranslationShort("DS Club")
                                 .orgTranslation("Data Science Club")
                                 .inactive(true)
@@ -179,7 +175,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/UCSBOrganization/post?orgCode=DSC&orgTranslationShort=DS Club&orgTranslation=Data Science Club&inactive=true")
+                                post("/api/UCSBOrganization/post?orgTranslationShort=DS Club&orgTranslation=Data Science Club&inactive=true")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -196,7 +192,6 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization boardgame = UCSBOrganization.builder()
-                                .orgCode("BGC")
                                 .orgTranslationShort("BG Club")
                                 .orgTranslation("Board Game Club")
                                 .inactive(true)
@@ -206,7 +201,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/UCSBOrganization?orgCode=BGC")
+                                delete("/api/UCSBOrganization?id=BGC")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
@@ -228,7 +223,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/UCSBOrganization?orgCode=iphone-users")
+                                delete("/api/UCSBOrganization?id=iphone-users")
                                                 .with(csrf()))
                                 .andExpect(status().isNotFound()).andReturn();
 
@@ -244,14 +239,12 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization facultyOrig = UCSBOrganization.builder()
-                                .orgCode("fac")
                                 .orgTranslationShort("faculty")
                                 .orgTranslation("Faculty Workers Only")
                                 .inactive(false)
                                 .build();
 
                 UCSBOrganization facultyEdited = UCSBOrganization.builder()
-                                .orgCode("facnstu")
                                 .orgTranslationShort("faculty & students")
                                 .orgTranslation("Faculty and Student Workers")
                                 .inactive(true)
@@ -263,7 +256,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/UCSBOrganization?orgCode=fac")
+                                put("/api/UCSBOrganization?id=fac")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)
@@ -283,7 +276,6 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 // arrange
 
                 UCSBOrganization editedOrgs = UCSBOrganization.builder()
-                                .orgCode("FM")
                                 .orgTranslationShort("F. Machines")
                                 .orgTranslation("Fast Machines")
                                 .inactive(true)
@@ -295,7 +287,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                put("/api/UCSBOrganization?orgCode=FM")
+                                put("/api/UCSBOrganization?id=FM")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .characterEncoding("utf-8")
                                                 .content(requestBody)


### PR DESCRIPTION
# Justification
This PR closes #21 
This PR closes #22 
This PR closes #23 
This PR closes #24 

# Implementation
I modeled my implementation of `UCSBOrganizationController.java` and `UCSBOrganizationControllerTests.java` to the example files in the repository.

# Testing
To test this change, you can run the following commands:
```bash
git checkout ak-ucsbOrgController
mvn clean
mvn test
mvn pitest:mutationCoverage
python3 -m http.server
```
and opening localhost:8000/target/pit-reports

## Acceptance criteria

**GET (index)/POST (create)**
- [x] There is a controller file `UCSBOrganizationController.java` in the expected directory.
- [x] In `UCSBOrganizationController.java` there is code for a `GET /api/UCSBOrganization/all` endpoint that returns a JSON list of all `UCSBOrganization`s in the database. (We sometimes call this an *index* action since it lists all items in the database.)
- [x] In `UCSBOrganizationController.java` there is code for a `POST /api/UCSBOrganization/post` endpoint that can be used to create a new entry in the table. (This is a *create* action.)
- [x] The Swagger-UI endpoints for these are well documented so that any member of the team can understand what they are for and how to use them.
- [x] The `POST` endpoint works as expected, in the sense that new records can be added to the database (on localhost).
- [x] The `GET` endpoint works as expected, in the sense that the new records that are added show up (on localhost).
- [x] The `GET` and `POST` endpoints work as expected when the app is deployed to Heroku.
- [x] There is full test coverage (Jacoco) for the methods in `UCSBOrganizationController.java`
- [x] There is full mutation test coverage (Pitest) for the methods in `UCSBOrganizationController.java`

**GET (show)**
- [x] In `UCSBOrganizationController.java` there is code for an endpoint `GET /api/UCSBOrganization?id=123` endpoint that returns the JSON of the database record with id 123 if it exists, or a 400 and the error message `id 123 not found` if it does not.
- [x] The Swagger-UI endpoints for this endpoint is well documented so that any member of the team can understand how to use it.
- [x] The endpoint works as expected on localhost.
- [x] The endpoint works as expected when deployed to Heroku.
- [x] There is full test coverage (Jacoco) for the new code in `UCSBOrganizationController.java`
- [x] There is full mutation test coverage (Pitest) for new code in `UCSBOrganizationController.java`

**PUT (edit)**
- [x] In `UCSBOrganizationController.java` there is code for an endpoint `PUT /api/UCSBOrganization?id=123` endpoint that accepts JSON for a new set of values for the database fields other than `id`, and updates the values of those fields.
- [x] The Swagger-UI endpoints for this endpoint is well documented so that any member of the team can understand how to use it.
- [x] The endpoint works as expected on localhost.
- [x] The endpoint works as expected when deployed to Heroku.
- [x] There is full test coverage (Jacoco) for the new code in `UCSBOrganizationController.java`
- [x] There is full mutation test coverage (Pitest) for new code in `UCSBOrganizationController.java`

**DELETE**
- [x] In `UCSBOrganizationController.java` there is code for an endpoint `DELETE /api/UCSBOrganization?id=123` endpoint 
      that deletes the record if it exists, and returns 200 (ok) and the text `record 123 deleted`, or returns 404 (Not Found) and the text `record 123 not found` if it does not.
- [x] The Swagger-UI endpoints for this endpoint is well documented so that any member of the team can understand how to use it.
- [x] The endpoint works as expected on localhost.
- [x] The endpoint works as expected when deployed to Heroku.
- [x] There is full test coverage (Jacoco) for the new code in `UCSBOrganizationController.java`
- [x] There is full mutation test coverage (Pitest) for new code in `UCSBOrganizationController.java`